### PR TITLE
Openning Trainer

### DIFF
--- a/src/components/LinearProgressBar.tsx
+++ b/src/components/LinearProgressBar.tsx
@@ -9,8 +9,6 @@ import {
 const LinearProgressBar = (
   props: LinearProgressProps & { value: number; label: string }
 ) => {
-  if (props.value === 0) return null;
-
   return (
     <Grid
       container

--- a/src/components/OpeningProgress.tsx
+++ b/src/components/OpeningProgress.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useState } from "react";
+import LinearProgressBar from "./LinearProgressBar";
+import { Button, Box } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+
+// Props :
+// - total : nombre total de variations
+// - openingKey : identifiant unique de l'ouverture (ex: 'italian')
+// - mode : 'learning' | 'training'
+//
+// - currentVariationIndex : index de la variation en cours (optionnel, pour affichage)
+
+interface OpeningProgressProps {
+  total: number;
+  openingKey: string;
+  mode: "learning" | "training";
+  // Liste des index de variations terminées
+  completed: number[];
+  onReset?: () => void;
+}
+
+const getStorageKey = (openingKey: string, mode: string) => `${openingKey}-progress-${mode}`;
+
+const OpeningProgress: React.FC<OpeningProgressProps> = ({
+  total,
+  openingKey,
+  mode,
+  completed,
+  onReset,
+}) => {
+  const [progress, setProgress] = useState<number[]>(completed);
+  const theme = useTheme();
+
+  useEffect(() => {
+    setProgress(completed);
+  }, [completed]);
+
+  // Calcul du pourcentage
+  const percent = total > 0 ? (progress.length / total) * 100 : 0;
+  const label = `${progress.length} / ${total}`;
+
+  // Réinitialisation
+  const handleReset = () => {
+    localStorage.removeItem(getStorageKey(openingKey, mode));
+    setProgress([]);
+    onReset && onReset();
+  };
+
+  return (
+    <Box
+      width={{ xs: "100%", sm: 320, md: 340 }}
+      sx={{
+        mt: { xs: 2, md: 3 },
+        mb: { xs: 0, md: 1 },
+        px: { xs: 0, sm: 1 },
+        alignSelf: "flex-end",
+        position: "relative",
+        left: 0,
+        bottom: 0,
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 1,
+      }}
+    >
+      <Box minWidth={48}>
+        <span style={{ fontSize: 14, color: theme.palette.text.secondary }}>{label}</span>
+      </Box>
+      <Box flex={1} minWidth={0}>
+        <LinearProgressBar value={percent} label={""} />
+      </Box>
+      <Button
+        size="small"
+        variant="contained"
+        color="primary"
+        sx={{
+          ml: 2,
+          borderRadius: 2,
+          textTransform: "none",
+          fontWeight: 500,
+          boxShadow: theme.shadows[1],
+          minWidth: 0,
+          px: 2,
+        }}
+        onClick={handleReset}
+      >
+        Réinitialiser
+      </Button>
+    </Box>
+  );
+};
+
+export default OpeningProgress;

--- a/src/components/board/index.tsx
+++ b/src/components/board/index.tsx
@@ -22,6 +22,12 @@ import PlayerHeader from "./playerHeader";
 import { boardHueAtom, pieceSetAtom } from "./states";
 import tinycolor from "tinycolor2";
 
+export interface TrainingFeedback {
+  square: string; // ex: 'e4'
+  icon: string;   // chemin de l'icône
+  alt: string;    // texte alternatif
+}
+
 export interface Props {
   id: string;
   canPlay?: Color | boolean;
@@ -34,6 +40,7 @@ export interface Props {
   showBestMoveArrow?: boolean;
   showPlayerMoveIconAtom?: PrimitiveAtom<boolean>;
   showEvaluationBar?: boolean;
+  trainingFeedback?: TrainingFeedback;
 }
 
 export default function Board({
@@ -48,6 +55,7 @@ export default function Board({
   showBestMoveArrow = false,
   showPlayerMoveIconAtom,
   showEvaluationBar = false,
+  trainingFeedback,
 }: Props) {
   const boardRef = useRef<HTMLDivElement>(null);
   const game = useAtomValue(gameAtom);
@@ -239,12 +247,14 @@ export default function Board({
       clickedSquaresAtom,
       playableSquaresAtom,
       showPlayerMoveIconAtom,
+      trainingFeedback, // nouvelle prop transmise
     });
   }, [
     currentPositionAtom,
     clickedSquaresAtom,
     playableSquaresAtom,
     showPlayerMoveIconAtom,
+    trainingFeedback,
   ]);
 
   const customPieces = useMemo(

--- a/src/components/board/squareRenderer.tsx
+++ b/src/components/board/squareRenderer.tsx
@@ -15,6 +15,11 @@ export interface Props {
   clickedSquaresAtom: PrimitiveAtom<Square[]>;
   playableSquaresAtom: PrimitiveAtom<Square[]>;
   showPlayerMoveIconAtom?: PrimitiveAtom<boolean>;
+  trainingFeedback?: {
+    square: string;
+    icon: string;
+    alt: string;
+  };
 }
 
 export function getSquareRenderer({
@@ -22,6 +27,7 @@ export function getSquareRenderer({
   clickedSquaresAtom,
   playableSquaresAtom,
   showPlayerMoveIconAtom = atom(false),
+  trainingFeedback,
 }: Props) {
   const squareRenderer = forwardRef<HTMLDivElement, CustomSquareProps>(
     (props, ref) => {
@@ -64,6 +70,25 @@ export function getSquareRenderer({
           {children}
           {highlightSquareStyle && <div style={highlightSquareStyle} />}
           {playableSquareStyle && <div style={playableSquareStyle} />}
+          {/* Affichage de l’icône de feedback training si demandé et sur la bonne case */}
+          {trainingFeedback && trainingFeedback.square === square && (
+            <img
+              src={trainingFeedback.icon}
+              alt={trainingFeedback.alt}
+              style={{
+                position: "absolute",
+                top: 0,
+                right: 0,
+                transform: "translate(35%,-35%)",
+                width: 28,
+                height: 28,
+                zIndex: 120,
+                pointerEvents: "none",
+                opacity: 0.95,
+              }}
+            />
+          )}
+          {/* Aucun affichage de message texte d'erreur ici, seulement l'icône */}
           {moveClassification && showPlayerMoveIcon && square === toSquare && (
             <Image
               src={`/icons/${moveClassification}.png`}

--- a/src/data/openings to learn/italian.ts
+++ b/src/data/openings to learn/italian.ts
@@ -1,0 +1,87 @@
+// italianGame.ts
+
+export type Move = string;
+
+export interface Variation {
+  name: string;
+  moves: Move[];
+}
+
+export const italianGameVariations: Variation[] = [
+  {
+    name: "Giuoco Piano",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "c3", "Nf6", "d3", "d6", "O-O", "O-O"],
+  },
+  {
+    name: "Evans Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "b4", "Bxb4", "c3", "Ba5", "d4", "exd4", "O-O"],
+  },
+  {
+    name: "Two Knights Defense",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6"],
+  },
+  {
+    name: "Fried Liver Attack",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "Ng5", "d5", "exd5", "Nxd5", "Nxf7", "Kxf7", "Qf3+", "Ke6", "Nc3"],
+  },
+  {
+    name: "Traxler Counterattack",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "Ng5", "Bc5"],
+  },
+  {
+    name: "Lolli Attack",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "Ng5", "d5", "exd5", "Nxd5", "d4"],
+  },
+  {
+    name: "Scotch Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "d4"],
+  },
+  {
+    name: "Hungarian Defense",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Be7"],
+  },
+  {
+    name: "Paris Defense",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "d6"],
+  },
+  {
+    name: "Rousseau Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "f5"],
+  },
+  {
+    name: "Blackburne Shilling Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nd4"],
+  },
+  {
+    name: "Jerome Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "Bxf7+", "Kxf7", "Nxe5+", "Nxe5", "Qh5+"],
+  },
+  {
+    name: "Rosentreter Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "d4", "exd4", "c3"],
+  },
+  {
+    name: "Neumann Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "c3", "Nf6", "Bc4"],
+  },
+  {
+    name: "Alexandre Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "c3", "f5"],
+  },
+  {
+    name: "Lucchini Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Bc5", "d3", "f5"],
+  },
+  {
+    name: "Ponziani-Steinitz Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "Ng5", "Nxe4"],
+  },
+  {
+    name: "Kloss Gambit",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "Ng5", "d5", "exd5", "Nb4"],
+  },
+  {
+    name: "Fegatello Attack",
+    moves: ["e4", "e5", "Nf3", "Nc6", "Bc4", "Nf6", "Ng5", "d5", "exd5", "Nxd5", "Nxf7", "Kxf7", "Qf3+", "Ke6", "Nc3"],
+  },
+];

--- a/src/pages/opening.tsx
+++ b/src/pages/opening.tsx
@@ -1,0 +1,294 @@
+import { italianGameVariations } from "../data/openings to learn/italian";
+import { Box, Typography, Button, Stack } from "@mui/material";
+import { useState, useMemo, useEffect } from "react";
+import Board from "../components/board";
+import { Chess } from "chess.js";
+import { atom, useAtom } from "jotai";
+import { useChessActions } from "../hooks/useChessActions";
+import { Color } from "../types/enums";
+import { CurrentPosition } from "../types/eval";
+import type { Variation } from "../data/openings to learn/italian";
+import OpeningProgress from "../components/OpeningProgress";
+
+// Détermine la couleur d'apprentissage pour la variante (par défaut blanc, mais extensible)
+function getLearningColor(variation: Variation): Color {
+  // TODO: utiliser variation.color si défini, sinon blanc
+  return Color.White;
+}
+
+export default function OpeningPage() {
+  const [currentVariantIdx, setCurrentVariantIdx] = useState(0);
+  const [moveIdx, setMoveIdx] = useState(0);
+  const [trainingMode, setTrainingMode] = useState(false);
+  const [lastMistake, setLastMistake] = useState<null | { from: string; to: string; type: string }>(null);
+  // Atom Jotai pour l'état du jeu
+  const [gameAtomInstance] = useState(() => atom(new Chess()));
+  const [game, setGame] = useAtom(gameAtomInstance);
+  const { undoMove } = useChessActions(gameAtomInstance);
+
+  // Liste des variantes à apprendre (toutes)
+  const variations = italianGameVariations;
+  const selectedVariation = variations[currentVariantIdx] || null;
+
+  // Couleur d'apprentissage (fixe pour la variante)
+  const learningColor = useMemo(() => {
+    if (!selectedVariation) return Color.White;
+    return getLearningColor(selectedVariation);
+  }, [selectedVariation]);
+
+  // Indique si c'est à l'utilisateur de jouer
+  const isUserTurn = useMemo(() => {
+    if (!selectedVariation) return false;
+    // moveIdx % 2 === 0 => blanc, 1 => noir (si la séquence commence par blanc)
+    const colorToPlay = moveIdx % 2 === 0 ? Color.White : Color.Black;
+    return colorToPlay === learningColor;
+  }, [moveIdx, learningColor, selectedVariation]);
+
+  // Génération du coup attendu au format UCI pour la flèche (uniquement si c'est à l'utilisateur de jouer)
+  const bestMoveUci = useMemo(() => {
+    if (
+      selectedVariation &&
+      game &&
+      moveIdx < selectedVariation.moves.length &&
+      isUserTurn
+    ) {
+      const chess = new Chess(game.fen());
+      const san = selectedVariation.moves[moveIdx];
+      const moves = chess.moves({ verbose: true });
+      const moveObj = moves.find((m) => m.san === san);
+      if (moveObj) {
+        return moveObj.from + moveObj.to + (moveObj.promotion ? moveObj.promotion : "");
+      }
+    }
+    return undefined;
+  }, [selectedVariation, game, moveIdx, isUserTurn]);
+
+  // Atom writable pour currentPosition (lecture/écriture)
+  const currentPositionAtom = useMemo(
+    () =>
+      atom<CurrentPosition>({
+        lastEval: bestMoveUci
+          ? {
+              bestMove: bestMoveUci,
+              lines: [
+                {
+                  pv: [bestMoveUci],
+                  depth: 10,
+                  multiPv: 1,
+                },
+              ],
+            }
+          : { lines: [] },
+        eval: {
+          moveClassification: undefined,
+          lines: [],
+        },
+      }),
+    [bestMoveUci]
+  );
+
+  // Réinitialisation à chaque variante ou progression
+  useEffect(() => {
+    if (!selectedVariation) return;
+    try {
+      const chess = new Chess();
+      for (let i = 0; i < moveIdx; i++) {
+        const move = selectedVariation.moves[i];
+        const result = chess.move(move);
+        if (!result) break; // Stop si coup invalide
+      }
+      setGame(chess);
+    } catch (e) {
+      // Gestion d'erreur : on évite le crash
+      setGame(new Chess());
+    }
+  }, [selectedVariation, moveIdx, setGame]);
+
+  // Validation du coup utilisateur : si mauvais coup, undo et annotation
+  useEffect(() => {
+    if (!selectedVariation || !game) return;
+    if (moveIdx >= selectedVariation.moves.length) return;
+    if (!isUserTurn) return; // On ne valide que les coups utilisateur
+    try {
+      const history = game.history({ verbose: true });
+      if (history.length !== moveIdx + 1) return;
+      const last = history[history.length - 1];
+      const expectedMove = new Chess();
+      for (let i = 0; i < moveIdx; i++) expectedMove.move(selectedVariation.moves[i]);
+      const expected = expectedMove.move(selectedVariation.moves[moveIdx]);
+      if (!expected || last.from !== expected.from || last.to !== expected.to) {
+        // Mauvais coup : annuler et annoter
+        let mistakeType = "Mistake";
+        if (last.captured || last.san.includes("#")) mistakeType = "Blunder";
+        setLastMistake({ from: last.from, to: last.to, type: mistakeType });
+        setTimeout(() => undoMove(), 350);
+      } else {
+        setLastMistake(null);
+        setMoveIdx((idx) => idx + 1);
+      }
+    } catch (e) {
+      // Gestion d'erreur : on évite le crash
+      setLastMistake(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [game.history().length, trainingMode, selectedVariation, isUserTurn]);
+
+  // Avance automatique des coups adverses après un coup utilisateur correct
+  useEffect(() => {
+    if (!selectedVariation) return;
+    if (moveIdx >= selectedVariation.moves.length) return;
+    // Si ce n'est pas à l'utilisateur de jouer, on avance automatiquement les coups adverses
+    if (!isUserTurn) {
+      // On joue tous les coups adverses jusqu'au prochain coup utilisateur ou fin de séquence
+      let nextIdx = moveIdx;
+      let colorToPlay = nextIdx % 2 === 0 ? Color.White : Color.Black;
+      while (nextIdx < selectedVariation.moves.length && colorToPlay !== learningColor) {
+        nextIdx++;
+        colorToPlay = nextIdx % 2 === 0 ? Color.White : Color.Black;
+      }
+      if (nextIdx !== moveIdx) {
+        // Délai augmenté à 500ms pour laisser le temps à l’animation du coup utilisateur
+        setTimeout(() => setMoveIdx(nextIdx), 500);
+      }
+    }
+  }, [moveIdx, isUserTurn, selectedVariation, learningColor]);
+
+  // Enchaînement automatique des variantes
+  useEffect(() => {
+    if (!selectedVariation) return;
+    if (moveIdx >= selectedVariation.moves.length) {
+      // Succès : passer à la variante suivante après un court délai
+      if (currentVariantIdx < variations.length - 1) {
+        setTimeout(() => {
+          setCurrentVariantIdx((idx) => idx + 1);
+          setMoveIdx(0);
+          setLastMistake(null);
+        }, 800);
+      }
+    }
+  }, [moveIdx, selectedVariation, currentVariantIdx, variations.length]);
+
+  // Si toutes les variantes sont terminées
+  const allDone = currentVariantIdx >= variations.length;
+
+  // Gestion de la progression (persistée par mode)
+  const openingKey = "italian";
+  const progressMode = trainingMode ? "training" : "learning";
+  const progressStorageKey = `${openingKey}-progress-${progressMode}`;
+  const [completedVariations, setCompletedVariations] = useState<number[]>(() => {
+    if (typeof window === "undefined") return [];
+    try {
+      const raw = localStorage.getItem(progressStorageKey);
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  });
+
+  // Marquer une variation comme terminée
+  useEffect(() => {
+    if (!selectedVariation) return;
+    if (moveIdx >= selectedVariation.moves.length) {
+      if (!completedVariations.includes(currentVariantIdx)) {
+        const updated = [...completedVariations, currentVariantIdx];
+        setCompletedVariations(updated);
+        localStorage.setItem(progressStorageKey, JSON.stringify(updated));
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [moveIdx, selectedVariation, currentVariantIdx, progressMode]);
+
+  // Réinitialisation de la progression
+  const handleResetProgress = () => {
+    localStorage.removeItem(progressStorageKey);
+    setCompletedVariations([]);
+  };
+
+  // Détermination de la case cible du dernier coup joué (pour overlay)
+  const lastMoveSquare = useMemo(() => {
+    if (!game) return null;
+    const history = game.history({ verbose: true });
+    if (history.length === 0) return null;
+    const last = history[history.length - 1];
+    return last.to;
+  }, [game]);
+
+  // Détermination du type d’icône à afficher (succès/erreur)
+  const trainingFeedback = useMemo(() => {
+    if (!trainingMode || !lastMoveSquare) return null;
+    // Afficher l'icône uniquement si le dernier coup a été joué par l'humain
+    // (c'est-à-dire si ce n'est plus à l'humain de jouer)
+    if (isUserTurn) return null;
+    if (lastMistake && lastMistake.to === lastMoveSquare) {
+      return { icon: "/icons/mistake.png", alt: "Coup incorrect" };
+    }
+    if (lastMistake === null && game.history().length > 0) {
+      // Remplacer l'icône de validation par book.png
+      return { icon: "/icons/book.png", alt: "Coup correct" };
+    }
+    return null;
+  }, [trainingMode, lastMistake, lastMoveSquare, game, isUserTurn]);
+
+  // Affichage principal
+  return (
+    <Box sx={{ flexGrow: 1, width: '100vw', minHeight: '100vh', p: { xs: 1, md: 4 }, boxSizing: 'border-box', bgcolor: 'background.default' }}>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={4} alignItems="stretch" justifyContent="center" sx={{ height: '100%' }}>
+        {/* Zone de gauche : contrôles et explications */}
+        <Box sx={{ flex: { xs: 'none', md: 1 }, minWidth: { md: 320 }, maxWidth: 420, mb: { xs: 2, md: 0 }, display: 'flex', flexDirection: 'column', height: '100%' }}>
+          {/* Titre de la variante */}
+          <Typography variant="h4" gutterBottom sx={{ mb: 2, wordBreak: 'break-word' }}>
+            {selectedVariation?.name}
+          </Typography>
+          {/* Espace aéré avant les boutons */}
+          <Box sx={{ flex: 1, mb: 2 }}>
+            <Stack direction="row" spacing={2} sx={{ mb: 3 }}>
+              <Button variant={trainingMode ? "contained" : "outlined"} onClick={() => setTrainingMode(true)}>
+                Training Mode
+              </Button>
+              <Button variant={!trainingMode ? "contained" : "outlined"} onClick={() => setTrainingMode(false)}>
+                Learning Mode
+              </Button>
+            </Stack>
+            {moveIdx >= selectedVariation.moves.length ? (
+              <Typography color="success.main" sx={{ mb: 2 }}>Variation complete! Next variation loading…</Typography>
+            ) : trainingMode ? (
+              <Typography color="text.secondary" sx={{ mb: 2 }}>Play the correct move to continue. Mistakes will be marked.</Typography>
+            ) : (
+              <Typography color="text.secondary" sx={{ mb: 2 }}>Play the move indicated by the arrow to continue.</Typography>
+            )}
+          </Box>
+          {/* Barre de progression en bas à gauche, toujours visible */}
+          <Box sx={{ mt: 'auto', width: '100%' }}>
+            <OpeningProgress
+              total={variations.length}
+              openingKey={openingKey}
+              mode={progressMode}
+              completed={completedVariations}
+              onReset={handleResetProgress}
+            />
+          </Box>
+        </Box>
+        {/* Zone de droite : échiquier responsive */}
+        <Box sx={{ flex: 2, display: 'flex', alignItems: 'center', justifyContent: 'center', minWidth: 0 }}>
+          {selectedVariation && !allDone && game && (
+            <Box sx={{ width: '100%', maxWidth: 600, aspectRatio: '1', minWidth: { xs: 260, sm: 340, md: 400 }, mx: 'auto', position: 'relative' }}>
+              <Board
+                id="LearningBoard"
+                canPlay={true}
+                gameAtom={gameAtomInstance}
+                boardSize={undefined} // Laisse le composant prendre toute la largeur
+                whitePlayer={{ name: "White" }}
+                blackPlayer={{ name: "Black" }}
+                showBestMoveArrow={!trainingMode}
+                currentPositionAtom={currentPositionAtom}
+                boardOrientation={learningColor}
+                // Nouvelle prop pour feedback visuel sur la case
+                trainingFeedback={trainingFeedback && lastMoveSquare ? { square: lastMoveSquare, ...trainingFeedback } : undefined}
+              />
+            </Box>
+          )}
+        </Box>
+      </Stack>
+    </Box>
+  );
+}

--- a/src/public/openings/italian-game.png
+++ b/src/public/openings/italian-game.png
@@ -1,0 +1,1 @@
+// Illustration d'ouverture Italienne pour la page Opening

--- a/src/sections/layout/NavMenu.tsx
+++ b/src/sections/layout/NavMenu.tsx
@@ -1,4 +1,4 @@
-import NavLink from "@/components/NavLink";
+import NavLink from "../../components/NavLink";
 import { Icon } from "@iconify/react";
 import {
   Box,
@@ -18,6 +18,11 @@ const MenuOptions = [
     text: "Database",
     icon: "streamline:database",
     href: "/database",
+  },
+  {
+    text: "Opening",
+    icon: "mdi:book-open-variant",
+    href: "/opening",
   },
 ];
 


### PR DESCRIPTION
This pull request introduces several new features and improvements, focusing on adding a new chess opening training page, enhancing the board component's functionality, and updating the navigation menu. Key changes include the implementation of a new `OpeningPage` for learning chess openings, support for visual feedback on the board, and the addition of Italian game variations.

Improvements needed :

- [ ] 1. Adding a small icon to indicate incorrect moves in Training Mode ( currently not working ).
- [ ] 2. Resizing the window, which is currently too large and still unresolved.
- [ ] 3. Adding support for learning other openings beyond the Italian Game.
- [ ] 4. Verifying the theoretical moves currently proposed for the Italian Game.
- [ ] 5. Add a feedback button so users can report errors in the openings or even suggest improvements.
- [ ] 6. The Reset button does not properly restart the current game the user is playing. It only clears the progress for the next time.