### PR TITLE
fix Warning:<div> cannot appear as a descendant of <p>

### DIFF
--- a/src/sections/loadGame/gameItem/index.tsx
+++ b/src/sections/loadGame/gameItem/index.tsx
@@ -47,6 +47,10 @@ export const GameItem: React.FC<Props> = ({
       onClick={onClick}
     >
       <ListItemText
+        slotProps={{
+          primary: { component: "div" },
+          secondary: { component: "div" },
+        }}
         primary={
           <Box
             sx={{


### PR DESCRIPTION
This commit removes a warning in GameItem component:

```
client.ts:62 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    at div
    at http://localhost:3000/_next/static/chunks/node_modules_abd93a6c._.js:4774:162
    at Chip (http://localhost:3000/_next/static/chunks/node_modules_%40mui_material_65032124._.js:23248:216)
    at Tooltip (http://localhost:3000/_next/static/chunks/node_modules_%40mui_material_65032124._.js:25663:216)
    at TimeControlChip (http://localhost:3000/_next/static/chunks/%5Broot%20of%20the%20server%5D__24a4dc4b._.js:17755:28)
    at div
    at http://localhost:3000/_next/static/chunks/node_modules_abd93a6c._.js:4774:162
    at Box (http://localhost:3000/_next/static/chunks/node_modules_%40mui_system_esm_a6675032._.js:4007:193)
    at p
    at http://localhost:3000/_next/static/chunks/node_modules_abd93a6c._.js:4774:162
    at Typography (http://localhost:3000/_next/static/chunks/node_modules_%40mui_material_71ee7364._.js:3348:235)
    at div
    at http://localhost:3000/_next/static/chunks/node_modules_abd93a6c._.js:4774:162
    at ListItemText (http://localhost:3000/_next/static/chunks/node_modules_%40mui_material_71ee7364._.js:10032:216)
    at li
    at http://localhost:3000/_next/static/chunks/node_modules_abd93a6c._.js:4774:162
    at ListItem (http://localhost:3000/_next/static/chunks/node_modules_%40mui_material_71ee7364._.js:9212:216)
    at GameItem (http://localhost:3000/_next/static/chunks/%5Broot%20of%20the%20server%5D__24a4dc4b._.js:18015:21)
    at ul
    ```