### PR TITLE
Add feature: Simple production docker container with configurable entry port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build Stage
+FROM node:lts-alpine3.22 AS build
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Build source
+COPY . .
+RUN npm run build
+
+# Production Stage
+FROM nginx:alpine AS production
+
+COPY --from=build /app/out /usr/share/nginx/html
+
+# Replace default nginx configuration
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+# Expose port (make sure this matches the nginx.conf!)
+EXPOSE 3000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -16,16 +16,20 @@
 </div>
 <br />
 
-Chesskit is an open-source chess website to play, view, analyze and review your chess games for free on any device with Stockfish !
+Chesskit is an open-source chess website to play, view, analyze and review your
+chess games for free on any device with Stockfish !
 
 ## Mission
 
-Chesskit aims to offer all the chess related features it can, while being free and open-source. It is designed to be easy to use, fast, and reliable.
+Chesskit aims to offer all the chess related features it can, while being free
+and open-source. It is designed to be easy to use, fast, and reliable.
 
 ## Features
 
-- Load and review games from [chess.com](https://chess.com) and [lichess.org](https://lichess.org)
-- Analysis board with live engine evaluation, custom arrows, evaluation graph, ...
+- Load and review games from [chess.com](https://chess.com) and
+  [lichess.org](https://lichess.org)
+- Analysis board with live engine evaluation, custom arrows, evaluation graph,
+  ...
 - Moves classification (Brilliant, Great, Good, Mistake, Blunder, ...)
 - Chess960 and Puzzles support
 - Play against Stockfish at any elo
@@ -35,13 +39,18 @@ Chesskit aims to offer all the chess related features it can, while being free a
 
 ## Stack
 
-Built with [Next.js](https://nextjs.org/docs), [React](https://react.dev/learn/describing-the-ui), [Material UI](https://mui.com/material-ui/getting-started/overview/), and [TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html).
+Built with [Next.js](https://nextjs.org/docs),
+[React](https://react.dev/learn/describing-the-ui),
+[Material UI](https://mui.com/material-ui/getting-started/overview/), and
+[TypeScript](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html).
 
-Deployed on AWS with [AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html), see it live [here](https://chesskit.org).
+Deployed on AWS with
+[AWS CDK](https://docs.aws.amazon.com/cdk/v2/guide/home.html), see it live
+[here](https://chesskit.org).
 
 ## Running the app in dev mode
 
-> [!IMPORTANT]  
+> [!IMPORTANT]\
 > At least [Node.js](https://nodejs.org) 22.11 is required.
 
 Install the dependencies :
@@ -56,7 +65,8 @@ Run the development server :
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in the browser to see the app running.
+Open [http://localhost:3000](http://localhost:3000) in the browser to see the
+app running.
 
 The app will automatically refresh on any source file change.
 
@@ -70,17 +80,32 @@ npm run lint
 
 ## Contribute
 
-See [contributing](CONTRIBUTING.md) for details on how to contribute to the project.
+See [contributing](CONTRIBUTING.md) for details on how to contribute to the
+project.
 
 ## Deploy
 
-To deploy the app, install [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and [authenticate](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html), then run :
+### AWS
+
+To deploy the app, install
+[AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)
+and
+[authenticate](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html),
+then run :
 
 ```bash
 npm run deploy
 ```
 
+### Docker
+
+Configure the `from` port in `docker-compose.yaml` as desired, then run:
+
+```bash
+docker compose up -d
+```
+
 ## License
 
-Chesskit is licensed under the GNU Affero General Public License 3. See [copying](COPYING.md) for
-details.
+Chesskit is licensed under the GNU Affero General Public License 3. See
+[copying](COPYING.md) for details.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  chesskit:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: Chesskit
+    image: GuillaumeSD/chesskit:latest
+    restart: unless-stopped
+    ports:
+      # from : to
+      - 3000:3000

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,9 +12,9 @@ server {
         try_files $uri /index.html;
     }
 
-    location /static/ {
-        root /usr/share/nginx/html;
-    }
+    # location /static/ {
+    #     root /usr/share/nginx/html;
+    # }
 
     # Handle 404 errors for React apps
     error_page 404 /index.html;

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen 3000;
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log warn;
+
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /static/ {
+        root /usr/share/nginx/html;
+    }
+
+    # Handle 404 errors for React apps
+    error_page 404 /index.html;
+}


### PR DESCRIPTION
closes #35 

- Added docker-compose.yaml: enables user to configure entry-port
- Added Dockerfile using lts-alpine3.22 as it meets required node version: [Docker definition](https://github.com/nodejs/docker-node/blob/b1e2c97844d5647bcfaf6d6c7862dd39fbc2ca51/22/alpine3.22/Dockerfile#L3)
- Added nginx.conf: deployment within container on port 3000.
- Changed README.md to add deployment through Docker