### PR TITLE
fix: evaluation bar shows 100% for mate positions

### DIFF
--- a/src/lib/engine/helpers/winPercentage.ts
+++ b/src/lib/engine/helpers/winPercentage.ts
@@ -18,8 +18,8 @@ export const getLineWinPercentage = (line: LineEval): number => {
 };
 
 const getWinPercentageFromMate = (mate: number): number => {
-  const mateInf = mate * Infinity;
-  return getWinPercentageFromCp(mateInf);
+  // Mate positions should be 100% for white advantage, 0% for black advantage
+  return mate > 0 ? 100 : 0;
 };
 
 // Source: https://github.com/lichess-org/lila/blob/a320a93b68dabee862b8093b1b2acdfe132b9966/modules/analyse/src/main/WinPercent.scala#L27


### PR DESCRIPTION
- Mate positions now return exactly 100%/0% instead of 97.54%
- Fixes issue where mate wasn't visually distinct from high CP

## Changes
- Modified `getWinPercentageFromMate()` to return exact 100%/0%

