### PR TITLE
Improved performance of loading games from Chess.com/Lichess

### DIFF
--- a/src/sections/loadGame/chessComInput.tsx
+++ b/src/sections/loadGame/chessComInput.tsx
@@ -23,7 +23,7 @@ export default function ChessComInput({ onSelect }: Props) {
     "chesscom-username",
     ""
   );
-  const [chessComUsername, setChessComUsername] = useState("");
+  const [chessComUsername, setChessComUsername] = useState(rawStoredValue?.split(",")[0] ?? "");
   const [hasEdited, setHasEdited] = useState(false);
 
   const storedValues = useMemo(() => {

--- a/src/sections/loadGame/chessComInput.tsx
+++ b/src/sections/loadGame/chessComInput.tsx
@@ -70,7 +70,7 @@ export default function ChessComInput({ onSelect }: Props) {
     setHasEdited(true);
   };
 
-  const debouncedUsername = useDebounce(chessComUsername, 300);
+  const debouncedUsername = useDebounce(chessComUsername, 450);
 
   const {
     data: games,

--- a/src/sections/loadGame/chessComInput.tsx
+++ b/src/sections/loadGame/chessComInput.tsx
@@ -74,7 +74,8 @@ export default function ChessComInput({ onSelect }: Props) {
 
   const {
     data: games,
-    isFetching,
+    isRefetching,
+    isLoading,
     isError,
   } = useQuery({
     queryKey: ["CCUserGames", debouncedUsername],
@@ -128,6 +129,8 @@ export default function ChessComInput({ onSelect }: Props) {
         />
       </FormControl>
 
+      {isRefetching && <CircularProgress sx={{ ml: 2 }} />}
+
       {debouncedUsername && (
         <Grid
           container
@@ -137,7 +140,7 @@ export default function ChessComInput({ onSelect }: Props) {
           minHeight={100}
           size={12}
         >
-          {isFetching ? (
+          {isLoading ? (
             <CircularProgress />
           ) : isError ? (
             <span style={{ color: "salmon" }}>

--- a/src/sections/loadGame/lichessInput.tsx
+++ b/src/sections/loadGame/lichessInput.tsx
@@ -23,7 +23,7 @@ export default function LichessInput({ onSelect }: Props) {
     "lichess-username",
     ""
   );
-  const [lichessUsername, setLichessUsername] = useState(rawStoredValue?.split(",")[0] ?? "");
+const [lichessUsername, setLichessUsername] = useState(rawStoredValue?.split(",")[0] ?? "");
   const [hasEdited, setHasEdited] = useState(false);
 
   const storedValues = useMemo(() => {
@@ -73,7 +73,8 @@ export default function LichessInput({ onSelect }: Props) {
 
   const {
     data: games,
-    isFetching,
+    isLoading,
+    isRefetching,
     isError,
   } = useQuery({
     queryKey: ["LichessUserGames", debouncedUsername],
@@ -127,6 +128,8 @@ export default function LichessInput({ onSelect }: Props) {
         />
       </FormControl>
 
+      {isRefetching && <CircularProgress sx={{ ml: 2 }} />}
+
       {debouncedUsername && (
         <Grid
           container
@@ -136,7 +139,7 @@ export default function LichessInput({ onSelect }: Props) {
           minHeight={100}
           size={12}
         >
-          {isFetching ? (
+          {isLoading ? (
             <CircularProgress />
           ) : isError ? (
             <span style={{ color: "salmon" }}>

--- a/src/sections/loadGame/lichessInput.tsx
+++ b/src/sections/loadGame/lichessInput.tsx
@@ -69,7 +69,7 @@ const [lichessUsername, setLichessUsername] = useState(rawStoredValue?.split(","
     setHasEdited(true);
   };
 
-  const debouncedUsername = useDebounce(lichessUsername, 500);
+  const debouncedUsername = useDebounce(lichessUsername, 450);
 
   const {
     data: games,

--- a/src/sections/loadGame/lichessInput.tsx
+++ b/src/sections/loadGame/lichessInput.tsx
@@ -23,7 +23,7 @@ export default function LichessInput({ onSelect }: Props) {
     "lichess-username",
     ""
   );
-  const [lichessUsername, setLichessUsername] = useState("");
+  const [lichessUsername, setLichessUsername] = useState(rawStoredValue?.split(",")[0] ?? "");
   const [hasEdited, setHasEdited] = useState(false);
 
   const storedValues = useMemo(() => {


### PR DESCRIPTION
- Automatically load the latest stored username from the storage
- Render query data from react-query cache (by using `isLoading` instead of `isFetching`)
- Set the username typing debounce delay to `450` for both CC and Lichess
