### PR TITLE
Fix navigator is not defined error

### DIFF
--- a/src/lib/engine/worker.ts
+++ b/src/lib/engine/worker.ts
@@ -45,6 +45,11 @@ export const sendCommandsToWorker = (
 };
 
 export const getRecommendedWorkersNb = (): number => {
+  // Return default value if navigator is not available (SSR)
+  if (typeof navigator === "undefined") {
+    return 2; // Safe default for server-side rendering
+  }
+
   const maxWorkersNbFromThreads = Math.max(
     1,
     Math.round(navigator.hardwareConcurrency - 4),


### PR DESCRIPTION
Closes #61 

While running locally (x86, linux) I get:

` ⨯ ReferenceError: navigator is not defined                                                                                                                                                 at getRecommendedWorkersNb (src/lib/engine/worker.ts:50:15)                                                                                                                             at <unknown> (src/sections/analysis/states.ts:23:24)                                                                                                                                  48 |   const maxWorkersNbFromThreads = Math.max(                                                                                                                                      
  49 |     1,       
> 50 |     Math.round(navigator.hardwareConcurrency - 4),                                                                                                                                    |               ^                                                                                                                                                                    51 |     Math.floor((navigator.hardwareConcurrency * 2) / 3)                                                                                                                            52 |   );                                                                                                                                                                             
  53 | {      `
  
 This PR solves this issue.