### PR TITLE
MoveClassification turn bug fixed

### DIFF
--- a/src/lib/engine/helpers/moveClassification.ts
+++ b/src/lib/engine/helpers/moveClassification.ts
@@ -51,7 +51,9 @@ export const getMovesClassification = (
 
     const lastPositionWinPercentage = positionsWinPercentage[index - 1];
     const positionWinPercentage = positionsWinPercentage[index];
-    const isWhiteMove = index % 2 === 1;
+
+    const sideToMove = fens[index - 1].split(" ")[1];
+    const isWhiteMove = sideToMove === "w";
 
     if (
       isSplendidMove(


### PR DESCRIPTION
- Fixed bug causing moves to be incorrectly marked as splendid from the black side by deriving the turn from the FEN directly and not from its index.