### PR TITLE
feat : share a game via a link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "firebase": "^11.1.0",
         "idb": "^8.0.1",
         "jotai": "^2.11.0",
+        "lz-string": "^1.5.0",
         "next": "16.2.3",
         "react": "19.2.5",
         "react-chessboard": "^4.7.3",
@@ -8775,6 +8776,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "firebase": "^11.1.0",
     "idb": "^8.0.1",
     "jotai": "^2.11.0",
+    "lz-string": "^1.5.0",
     "next": "16.2.3",
     "react": "19.2.5",
     "react-chessboard": "^4.7.3",

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Copies text to the clipboard and reports the success for a short while, so
+ * that buttons can acknowledge the copy without any notification system.
+ */
+export const useCopyToClipboard = (resetDelayMs = 2000) => {
+  const [hasCopied, setHasCopied] = useState(false);
+  const resetTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  useEffect(() => () => clearTimeout(resetTimeout.current), []);
+
+  const copy = useCallback(
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch (error) {
+        console.error("Error copying to clipboard:", error);
+        return;
+      }
+
+      setHasCopied(true);
+      clearTimeout(resetTimeout.current);
+      resetTimeout.current = setTimeout(
+        () => setHasCopied(false),
+        resetDelayMs
+      );
+    },
+    [resetDelayMs]
+  );
+
+  return { copy, hasCopied };
+};

--- a/src/lib/shareGame.ts
+++ b/src/lib/shareGame.ts
@@ -1,0 +1,33 @@
+import {
+  compressToEncodedURIComponent,
+  decompressFromEncodedURIComponent,
+} from "lz-string";
+import { getGameFromPgn } from "./chess";
+
+/**
+ * A shared game lives entirely in its link: the PGN is compressed so that even
+ * long games fit in a URL that can be pasted anywhere.
+ */
+export const getGameShareUrl = (pgn: string, orientation: boolean): string => {
+  const params = new URLSearchParams({
+    pgn: compressToEncodedURIComponent(pgn),
+  });
+  if (!orientation) params.set("orientation", "black");
+
+  const { origin, pathname } = window.location;
+
+  return `${origin}${pathname}?${params.toString()}`;
+};
+
+export const getPgnFromShareParam = (param: string): string | undefined => {
+  try {
+    const pgn = decompressFromEncodedURIComponent(param);
+    if (!pgn) return undefined;
+
+    getGameFromPgn(pgn); // throws if the shared PGN is not a valid game
+
+    return pgn;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/sections/analysis/panelHeader/loadGame.tsx
+++ b/src/sections/analysis/panelHeader/loadGame.tsx
@@ -14,6 +14,7 @@ import { Chess } from "chess.js";
 import { useRouter } from "next/router";
 import { GameEval } from "@/types/eval";
 import { fetchLichessGame } from "@/lib/lichess";
+import { getPgnFromShareParam } from "@/lib/shareGame";
 
 export default function LoadGame() {
   const router = useRouter();
@@ -41,7 +42,11 @@ export default function LoadGame() {
     [joinedGameHistory, resetBoard, setGamePgn, setEval, setBoardOrientation]
   );
 
-  const { lichessGameId, orientation: orientationParam } = router.query;
+  const {
+    lichessGameId,
+    orientation: orientationParam,
+    pgn: pgnParam,
+  } = router.query;
 
   useEffect(() => {
     const handleLichess = async (id: string) => {
@@ -58,8 +63,19 @@ export default function LoadGame() {
       resetAndSetGamePgn(gameFromUrl.pgn, orientation, gameFromUrl.eval);
     } else if (typeof lichessGameId === "string" && !!lichessGameId) {
       handleLichess(lichessGameId);
+    } else if (typeof pgnParam === "string" && !!pgnParam) {
+      const sharedPgn = getPgnFromShareParam(pgnParam);
+      if (sharedPgn) {
+        resetAndSetGamePgn(sharedPgn, orientationParam !== "black");
+      }
     }
-  }, [gameFromUrl, lichessGameId, orientationParam, resetAndSetGamePgn]);
+  }, [
+    gameFromUrl,
+    lichessGameId,
+    orientationParam,
+    pgnParam,
+    resetAndSetGamePgn,
+  ]);
 
   useEffect(() => {
     const eventHandler = (event: MessageEvent) => {

--- a/src/sections/analysis/panelToolbar/copyPgnButton.tsx
+++ b/src/sections/analysis/panelToolbar/copyPgnButton.tsx
@@ -1,17 +1,19 @@
 import { useAtomValue } from "jotai";
 import { gameAtom } from "../states";
 import { ToolbarButton } from "@/components/ToolbarButton";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 export const CopyPgnButton = () => {
   const game = useAtomValue(gameAtom);
+  const { copy, hasCopied } = useCopyToClipboard();
 
   return (
     <ToolbarButton
-      tooltip="Copy PGN"
+      tooltip={hasCopied ? "PGN copied!" : "Copy PGN"}
       onClick={() => {
-        navigator.clipboard?.writeText?.(game.pgn());
+        copy(game.pgn());
       }}
-      icon="ri:clipboard-line"
+      icon={hasCopied ? "ri:clipboard-fill" : "ri:clipboard-line"}
       disabled={game.history().length === 0}
     />
   );

--- a/src/sections/analysis/panelToolbar/index.tsx
+++ b/src/sections/analysis/panelToolbar/index.tsx
@@ -9,6 +9,7 @@ import SaveButton from "./saveButton";
 import { useEffect } from "react";
 import { ToolbarButton } from "@/components/ToolbarButton";
 import { CopyPgnButton } from "./copyPgnButton";
+import { ShareGameButton } from "./shareGameButton";
 
 export default function PanelToolBar() {
   const board = useAtomValue(boardAtom);
@@ -69,6 +70,7 @@ export default function PanelToolBar() {
         {isSmOrGreater && (
           <>
             <CopyPgnButton />
+            <ShareGameButton />
             <SaveButton />
           </>
         )}
@@ -83,6 +85,7 @@ export default function PanelToolBar() {
         >
           <FlipBoardButton />
           <CopyPgnButton />
+          <ShareGameButton />
           <SaveButton />
         </Stack>
       )}

--- a/src/sections/analysis/panelToolbar/shareGameButton.tsx
+++ b/src/sections/analysis/panelToolbar/shareGameButton.tsx
@@ -1,0 +1,27 @@
+import { useAtomValue } from "jotai";
+import { boardAtom, boardOrientationAtom, gameAtom } from "../states";
+import { ToolbarButton } from "@/components/ToolbarButton";
+import { getGameToSave } from "@/lib/chess";
+import { getGameShareUrl } from "@/lib/shareGame";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+
+export const ShareGameButton = () => {
+  const game = useAtomValue(gameAtom);
+  const board = useAtomValue(boardAtom);
+  const boardOrientation = useAtomValue(boardOrientationAtom);
+  const { copy, hasCopied } = useCopyToClipboard();
+
+  const enableShare = !!(game.history().length || board.history().length);
+
+  return (
+    <ToolbarButton
+      tooltip={hasCopied ? "Link copied!" : "Copy game link"}
+      icon={hasCopied ? "ri:check-line" : "ri:link"}
+      onClick={() => {
+        const gameToShare = getGameToSave(game, board);
+        copy(getGameShareUrl(gameToShare.pgn(), boardOrientation));
+      }}
+      disabled={!enableShare}
+    />
+  );
+};


### PR DESCRIPTION
## What

Adds a **share button** to the analysis toolbar. It copies a link that contains the whole game, so a game can be shared without saving it or uploading it anywhere.

Opening the link restores the game (and the board orientation) on the analysis page.

This picks up the idea of #86 and rebases it on current `main`.

## How

- `src/lib/shareGame.ts` builds and reads the link. The PGN is compressed with [`lz-string`](https://www.npmjs.com/package/lz-string) into a `pgn` query param.
- Loading is handled in `LoadGame`, in the same `useEffect` that already handles `gameId` and `lichessGameId`, and reuses the existing `orientation` param.
- The share param is validated before use: it must decompress **and** parse as a valid PGN, otherwise it is ignored. A broken or truncated link leaves the page in its normal empty state instead of throwing.
- Clipboard feedback lives in a small `useCopyToClipboard` hook (the tooltip and icon confirm the copy for 2s). The existing *Copy PGN* button now uses it too, so both clipboard buttons behave the same way.

## Why compress

`lz-string`'s `compressToEncodedURIComponent` outputs URL-safe characters directly, so there is no percent-escaping on top of it. On a 61-ply game:

| | length |
|---|---|
| raw PGN | 448 |
| `encodeURIComponent(pgn)` | 754 |
| `compressToEncodedURIComponent(pgn)` | **392** |

So a shared link is roughly half the size of one carrying a plain PGN, and it grows slowly since PGN text compresses well. No `@types/lz-string` is needed — `lz-string` ships its own typings.

## Notes

- No URL length cap. Even a long annotated game stays well under the limits of browsers and messaging apps, so a cap would only add a failure mode to explain.
- Sharing uses `getGameToSave(game, board)`, the same helper as the save button, so a game played on the board gets proper headers before being shared.

## Tested

- `npm run lint` (eslint + `tsc --noEmit`) and `npm run build` pass.
- Manually: sharing a game produces a link that reloads the same game with the right orientation, and a deliberately corrupted `?pgn=` param is ignored without breaking the page.


## If the URL ever needs to be shorter

Compressing the PGN as text is the cheapest thing that works, and it keeps headers, comments and variations. For the record, here is what the alternatives cost. Sizes are for an 80-ply game; decode is timed in headless Chrome under `Emulation.setCPUThrottlingRate` at ×8, roughly a mid-tier phone. `loadPgn` alone costs 4.9 ms there, which is the floor any scheme has to pay.

| option | URL | decode | + | − |
|---|---|---|---|---|
| **lz-string on the PGN — this PR** | 538 | 4.9 ms | free: decoding costs exactly what `loadPgn` already costs. Keeps headers and comments | longest URL |
| strip headers and move numbers, then compress | ~½ | ~unchanged | ~2× shorter for a few lines, same format, no new dependency | loses names/date/result unless re-added as separate params |
| native `CompressionStream('deflate-raw')` | ~same | ~unchanged | drops the `lz-string` dependency | async, and only ~5% better than lz-string once headers are stripped, so it buys little on its own |
| binary: from/to on 12 bits per ply | 164 | 16.6 ms | 3.4× shorter, ~1 frame, decoder only has to apply moves | drops everything that is not a move; needs a versioned format |
| binary: index in the sorted legal-move list | 76 | 39.3 ms | 7× shorter, ~5.5 bits per ply — the practical minimum | 8× the decode cost, and 306 ms for a 273-ply game on a low-end phone. Couples the link format to chess.js move generation, so an upgrade can silently break links already shared |
| short link backed by storage | ~30 | one request | URL size stops depending on game length | server state, retention and privacy, and links no longer work forever by construction |

Two dead ends I checked: deflating either binary stream makes it *bigger* (it is already near-uniform), and base64url's fixed 33% overhead can only be cut by ~5% with a URL-safe base85 alphabet.

If this ever needs to shrink, `from/to` looks like the sweet spot — the legal-move index is the true minimum but has the worst ratio. Happy to do either as a follow-up; I kept this PR to the simple version on purpose.
