### PR TITLE
fix : copy the wrong game PGN after a deletion

### DIFF
--- a/src/pages/database.tsx
+++ b/src/pages/database.tsx
@@ -41,7 +41,11 @@ export default function GameDatabase() {
       if (typeof id !== "number") {
         throw new Error("Unable to copy game");
       }
-      await navigator.clipboard?.writeText?.(games[id - 1].pgn);
+      const game = games.find((g) => g.id === id);
+      if (!game) {
+        throw new Error(`Game ${id} not found`);
+      }
+      await navigator.clipboard?.writeText?.(game.pgn);
     },
     [games]
   );

--- a/src/pages/database.tsx
+++ b/src/pages/database.tsx
@@ -24,8 +24,6 @@ export default function GameDatabase() {
   const { games, deleteGame } = useGameDatabase(true);
   const router = useRouter();
 
-  console.log(games);
-
   const handleDeleteGameRow = useCallback(
     (id: GridRowId) => async () => {
       if (typeof id !== "number") {


### PR DESCRIPTION
### Problem

On `/database`, the games grid is rendered with `rows={games}` and no `getRowId`, so MUI DataGrid derives each row id from `Game.id` — the IndexedDB auto-increment key.

`handleCopyGameRow` treats that key as an array index:

```ts
await navigator.clipboard?.writeText?.(games[id - 1].pgn);
```

Keys are only dense until a game is deleted. Afterwards they go sparse (`1, 2, 4, 5`) while `games` stays contiguous, so the two stop lining up.

### Steps to reproduce

1. Save three games, so ids are `1, 2, 3`.
2. Delete the first one. Remaining ids are `2, 3`; `games` has length 2.
3. Click copy on the game with id `3`.

`games[2]` is `undefined`, so it throws on `undefined.pgn`. With more games saved it silently copies a different game's PGN instead, which is the worse outcome since there is no visible error.

### Fix

Look the game up by key rather than by position — the same value `handleDeleteGameRow` already passes straight to `deleteGame(id)`:

```ts
const game = games.find((g) => g.id === id);
if (!game) {
  throw new Error(`Game ${id} not found`);
}
await navigator.clipboard?.writeText?.(game.pgn);
```

The second commit drops an unrelated `console.log(games)` that was firing on every render of the same page. Happy to split that out if you would rather keep the PR to a single concern.

`npm run lint` passes.